### PR TITLE
Improve diff comment ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ Thumbs.db
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*
+
+# Ignore editor config
+/.idea

--- a/__tests__/DiffChecker.test.ts
+++ b/__tests__/DiffChecker.test.ts
@@ -1,0 +1,62 @@
+import { DiffChecker } from "../src/DiffChecker";
+
+describe("DiffChecker", () => {
+  const mock100Coverage = {
+    total: 100,
+    covered: 100,
+    skipped: 0,
+    pct: 100,
+  }
+  const mock99Coverage = {
+    total: 100,
+    covered: 99,
+    skipped: 1,
+    pct: 99,
+  }
+  const mockEmptyCoverage = {
+    total: 100,
+    covered: 0,
+    skipped: 100,
+    pct: 0,
+  }
+  const mock99CoverageFile = {
+    statements: mock99Coverage,
+    branches: mock99Coverage,
+    functions: mock99Coverage,
+    lines: mock99Coverage,
+  };
+  const mock100CoverageFile = {
+    statements: mock100Coverage,
+    branches: mock100Coverage,
+    functions: mock100Coverage,
+    lines: mock100Coverage,
+  }
+  const mockEmptyCoverageFile = {
+    statements: mockEmptyCoverage,
+    branches: mockEmptyCoverage,
+    functions: mockEmptyCoverage,
+    lines: mockEmptyCoverage,
+  }
+  it("generates the correct diff", () => {
+    const codeCoverageOld = {
+      file1: mock99CoverageFile,
+      file2: mock100CoverageFile,
+      file3: mockEmptyCoverageFile,
+      file4: mock100CoverageFile,
+    };
+    const codeCoverageNew = {
+      file1: mock100CoverageFile,
+      file2: mock99CoverageFile,
+      file3: mock100CoverageFile,
+      file4: mockEmptyCoverageFile,
+    };
+    const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld);
+    const details =  diffChecker.getCoverageDetails(false, "")
+    expect(details).toStrictEqual([
+      " :green_circle: | file1 | 100 **(1)** | 100 **(1)** | 100 **(1)** | 100 **(1)**",
+      " :red_circle: | file2 | 99 **(-1)** | 99 **(-1)** | 99 **(-1)** | 99 **(-1)**",
+      " :new: | **file3** | **100** | **100** | **100** | **100**",
+      " :red_circle: | ~~file4~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~",
+    ])
+  });
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -2046,7 +2046,8 @@ function run() {
                 .toString()
                 .trim();
             const diffChecker = new DiffChecker_1.DiffChecker(codeCoverageNew, codeCoverageOld);
-            let messageToPost = `Code coverage diff between base branch:${branchNameBase} and head branch: ${branchNameHead} \n`;
+            let messageToPost = `## Test coverage results :test_tube: \n
+    Code coverage diff between base branch:${branchNameBase} and head branch: ${branchNameHead} \n`;
             const coverageDetails = diffChecker.getCoverageDetails(!fullCoverage, `${currentDirectory}/`);
             if (coverageDetails.length === 0) {
                 messageToPost =

--- a/dist/index.js
+++ b/dist/index.js
@@ -2054,7 +2054,7 @@ function run() {
             }
             else {
                 messageToPost +=
-                    'File | % Stmts | % Branch | % Funcs | % Lines \n -----|---------|----------|---------|------ \n';
+                    'Status | File | % Stmts | % Branch | % Funcs | % Lines \n -----|-----|---------|----------|---------|------ \n';
                 messageToPost += coverageDetails.join('\n');
             }
             yield githubClient.issues.createComment({
@@ -6676,6 +6676,9 @@ module.exports = isPlainObject;
 
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.DiffChecker = void 0;
+const increasedCoverageIcon = ':green_circle:';
+const decreasedCoverageIcon = ':red_circle:';
+const newCoverageIcon = ':new:';
 class DiffChecker {
     constructor(coverageReportNew, coverageReportOld) {
         this.diffCoverageReport = {};
@@ -6744,9 +6747,7 @@ class DiffChecker {
             const keys = Object.keys(diffCoverageData);
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-                    const oldValue = Number(diffCoverageData[key].oldPct);
-                    const newValue = Number(diffCoverageData[key].newPct);
-                    if (oldValue - newValue > delta) {
+                    if (this.getPercentageDiff(diffCoverageData[key]) > delta) {
                         return true;
                     }
                 }
@@ -6756,12 +6757,16 @@ class DiffChecker {
     }
     createDiffLine(name, diffFileCoverageData) {
         if (!diffFileCoverageData.branches.oldPct) {
-            return `**${name}** | **${diffFileCoverageData.statements.newPct}** | **${diffFileCoverageData.branches.newPct}** | **${diffFileCoverageData.functions.newPct}** | **${diffFileCoverageData.lines.newPct}**`;
+            // No old coverage found so that means we added a new file coverage
+            return ` ${newCoverageIcon} | **${name}** | **${diffFileCoverageData.statements.newPct}** | **${diffFileCoverageData.branches.newPct}** | **${diffFileCoverageData.functions.newPct}** | **${diffFileCoverageData.lines.newPct}**`;
         }
         else if (!diffFileCoverageData.branches.newPct) {
-            return `~~${name}~~ | ~~${diffFileCoverageData.statements.oldPct}~~ | ~~${diffFileCoverageData.branches.oldPct}~~ | ~~${diffFileCoverageData.functions.oldPct}~~ | ~~${diffFileCoverageData.lines.oldPct}~~`;
+            // No new coverage found so that means we added a new deleted coverage
+            return ` ${decreasedCoverageIcon} | ~~${name}~~ | ~~${diffFileCoverageData.statements.oldPct}~~ | ~~${diffFileCoverageData.branches.oldPct}~~ | ~~${diffFileCoverageData.functions.oldPct}~~ | ~~${diffFileCoverageData.lines.oldPct}~~`;
         }
-        return `${name} | ~~${diffFileCoverageData.statements.oldPct}~~ **${diffFileCoverageData.statements.newPct}** | ~~${diffFileCoverageData.branches.oldPct}~~ **${diffFileCoverageData.branches.newPct}** | ~~${diffFileCoverageData.functions.oldPct}~~ **${diffFileCoverageData.functions.newPct}** | ~~${diffFileCoverageData.lines.oldPct}~~ **${diffFileCoverageData.lines.newPct}**`;
+        // Coverage existed before so calculate the diff status
+        const statusIcon = this.getStatusIcon(diffFileCoverageData);
+        return ` ${statusIcon} | ${name} | ${diffFileCoverageData.statements.newPct} **(${this.getPercentageDiff(diffFileCoverageData.statements)})** | ${diffFileCoverageData.branches.newPct} **(${this.getPercentageDiff(diffFileCoverageData.branches)})** | ${diffFileCoverageData.functions.newPct} **(${this.getPercentageDiff(diffFileCoverageData.functions)})** | ${diffFileCoverageData.lines.newPct} **(${this.getPercentageDiff(diffFileCoverageData.lines)})**`;
     }
     compareCoverageValues(diffCoverageData) {
         const keys = Object.keys(diffCoverageData);
@@ -6774,6 +6779,19 @@ class DiffChecker {
     }
     getPercentage(coverageData) {
         return coverageData.pct;
+    }
+    getStatusIcon(diffFileCoverageData) {
+        let overallDiff = 0;
+        Object.values(diffFileCoverageData).forEach(coverageData => {
+            overallDiff = overallDiff + this.getPercentageDiff(coverageData);
+        });
+        if (overallDiff < 0) {
+            return decreasedCoverageIcon;
+        }
+        return increasedCoverageIcon;
+    }
+    getPercentageDiff(diffData) {
+        return Number(diffData.newPct) - Number(diffData.oldPct);
     }
 }
 exports.DiffChecker = DiffChecker;

--- a/dist/index.js
+++ b/dist/index.js
@@ -6748,7 +6748,7 @@ class DiffChecker {
             const keys = Object.keys(diffCoverageData);
             for (const key of keys) {
                 if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-                    if (this.getPercentageDiff(diffCoverageData[key]) > delta) {
+                    if (-this.getPercentageDiff(diffCoverageData[key]) > delta) {
                         return true;
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -6791,7 +6791,10 @@ class DiffChecker {
         return increasedCoverageIcon;
     }
     getPercentageDiff(diffData) {
-        return Number(diffData.newPct) - Number(diffData.oldPct);
+        // get diff
+        const diff = Number(diffData.newPct) - Number(diffData.oldPct);
+        // round off the diff to 2 decimal places
+        return Math.round((diff + Number.EPSILON) * 100) / 100;
     }
 }
 exports.DiffChecker = DiffChecker;

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -166,6 +166,9 @@ export class DiffChecker {
   }
 
   private getPercentageDiff(diffData: DiffCoverageData): number {
-    return Number(diffData.newPct) - Number(diffData.oldPct)
+    // get diff
+    const diff = Number(diffData.newPct) - Number(diffData.oldPct)
+    // round off the diff to 2 decimal places
+    return Math.round((diff + Number.EPSILON) * 100) / 100
   }
 }

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -100,7 +100,7 @@ export class DiffChecker {
       >Object.keys(diffCoverageData)
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-          if (this.getPercentageDiff(diffCoverageData[key]) > delta) {
+          if (-this.getPercentageDiff(diffCoverageData[key]) > delta) {
             return true
           }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ async function run(): Promise<void> {
         'No changes to code coverage between the base branch and the head branch'
     } else {
       messageToPost +=
-        'File | % Stmts | % Branch | % Funcs | % Lines \n -----|---------|----------|---------|------ \n'
+        'Status | File | % Stmts | % Branch | % Funcs | % Lines \n -----|---------|----------|---------|------ \n'
       messageToPost += coverageDetails.join('\n')
     }
     await githubClient.issues.createComment({

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,8 @@ async function run(): Promise<void> {
       codeCoverageNew,
       codeCoverageOld
     )
-    let messageToPost = `Code coverage diff between base branch:${branchNameBase} and head branch: ${branchNameHead} \n`
+    let messageToPost = `## Test coverage results :test_tube: \n
+    Code coverage diff between base branch:${branchNameBase} and head branch: ${branchNameHead} \n`
     const coverageDetails = diffChecker.getCoverageDetails(
       !fullCoverage,
       `${currentDirectory}/`

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ async function run(): Promise<void> {
         'No changes to code coverage between the base branch and the head branch'
     } else {
       messageToPost +=
-        'Status | File | % Stmts | % Branch | % Funcs | % Lines \n -----|---------|----------|---------|------ \n'
+        'Status | File | % Stmts | % Branch | % Funcs | % Lines \n -----|-----|---------|----------|---------|------ \n'
       messageToPost += coverageDetails.join('\n')
     }
     await githubClient.issues.createComment({


### PR DESCRIPTION
## Description
Improves the UI of the diff comment that gets added

- Adds a status icon by comparing % diff across different coverage metrics
- Removes the ~~strike off~~ UI and instead shows the % change in brackets `**(-20)**`
- Adds a nice header to the comment
- Adds test for the DiffChecker class

The output would look like this now

Status | File | % Stmts | % Branch | % Funcs | % Lines
-----|-----|---------|----------|---------|------
:green_circle: | file1 | 100 **(1)** | 100 **(1)** | 100 **(1)** | 100 **(1)**
:red_circle: | file2 | 99 **(-1)** | 99 **(-1)** | 99 **(-1)** | 99 **(-1)**
:new: | **file3** | **100** | **100** | **100** | **100**
:red_circle: | ~~file4~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~

