### PR TITLE
Fix for new and removed coverage diffs getting marked incorrectly

### DIFF
--- a/__tests__/DiffChecker.test.ts
+++ b/__tests__/DiffChecker.test.ts
@@ -41,7 +41,6 @@ describe("DiffChecker", () => {
     const codeCoverageOld = {
       file1: mock99CoverageFile,
       file2: mock100CoverageFile,
-      file3: mockEmptyCoverageFile,
       file4: mock100CoverageFile,
       file5: mock99CoverageFile,
     };
@@ -49,7 +48,6 @@ describe("DiffChecker", () => {
       file1: mock100CoverageFile,
       file2: mock99CoverageFile,
       file3: mock100CoverageFile,
-      file4: mockEmptyCoverageFile,
       file5: {
         statements: mock99Coverage,
         branches: mockEmptyCoverage,
@@ -63,8 +61,8 @@ describe("DiffChecker", () => {
       " :green_circle: | file1 | 100 **(1)** | 100 **(1)** | 100 **(1)** | 100 **(1)**",
       " :red_circle: | file2 | 99 **(-1)** | 99 **(-1)** | 99 **(-1)** | 99 **(-1)**",
       " :sparkles: :new: | **file3** | **100** | **100** | **100** | **100**",
-      " :x: | ~~file4~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~",
       " :red_circle: | file5 | 99 **(0)** | 0 **(-99)** | 99 **(0)** | 99 **(0)**",
+      " :x: | ~~file4~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~",
     ])
   });
 });

--- a/__tests__/DiffChecker.test.ts
+++ b/__tests__/DiffChecker.test.ts
@@ -43,20 +43,28 @@ describe("DiffChecker", () => {
       file2: mock100CoverageFile,
       file3: mockEmptyCoverageFile,
       file4: mock100CoverageFile,
+      file5: mock99CoverageFile,
     };
     const codeCoverageNew = {
       file1: mock100CoverageFile,
       file2: mock99CoverageFile,
       file3: mock100CoverageFile,
       file4: mockEmptyCoverageFile,
+      file5: {
+        statements: mock99Coverage,
+        branches: mockEmptyCoverage,
+        functions: mock99Coverage,
+        lines: mock99Coverage,
+      },
     };
     const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld);
     const details =  diffChecker.getCoverageDetails(false, "")
     expect(details).toStrictEqual([
       " :green_circle: | file1 | 100 **(1)** | 100 **(1)** | 100 **(1)** | 100 **(1)**",
       " :red_circle: | file2 | 99 **(-1)** | 99 **(-1)** | 99 **(-1)** | 99 **(-1)**",
-      " :new: | **file3** | **100** | **100** | **100** | **100**",
-      " :red_circle: | ~~file4~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~",
+      " :sparkles: :new: | **file3** | **100** | **100** | **100** | **100**",
+      " :x: | ~~file4~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~",
+      " :red_circle: | file5 | 99 **(0)** | 0 **(-99)** | 99 **(0)** | 99 **(0)**",
     ])
   });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -6782,7 +6782,7 @@ class DiffChecker {
         return 0;
     }
     getPercentage(coverageData) {
-        return coverageData.pct;
+        return coverageData.pct || 0;
     }
     getStatusIcon(diffFileCoverageData) {
         let overallDiff = 0;

--- a/dist/index.js
+++ b/dist/index.js
@@ -6679,7 +6679,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.DiffChecker = void 0;
 const increasedCoverageIcon = ':green_circle:';
 const decreasedCoverageIcon = ':red_circle:';
-const newCoverageIcon = ':new:';
+const newCoverageIcon = ':sparkles: :new:';
+const removedCoverageIcon = ':x:';
 class DiffChecker {
     constructor(coverageReportNew, coverageReportOld) {
         this.diffCoverageReport = {};
@@ -6757,13 +6758,15 @@ class DiffChecker {
         return false;
     }
     createDiffLine(name, diffFileCoverageData) {
-        if (!diffFileCoverageData.branches.oldPct) {
-            // No old coverage found so that means we added a new file coverage
+        // No old coverage found so that means we added a new file coverage
+        const fileNewCoverage = Object.values(diffFileCoverageData).every(coverageData => coverageData.oldPct === 0);
+        // No new coverage found so that means we deleted a file coverage
+        const fileRemovedCoverage = Object.values(diffFileCoverageData).every(coverageData => coverageData.newPct === 0);
+        if (fileNewCoverage) {
             return ` ${newCoverageIcon} | **${name}** | **${diffFileCoverageData.statements.newPct}** | **${diffFileCoverageData.branches.newPct}** | **${diffFileCoverageData.functions.newPct}** | **${diffFileCoverageData.lines.newPct}**`;
         }
-        else if (!diffFileCoverageData.branches.newPct) {
-            // No new coverage found so that means we added a new deleted coverage
-            return ` ${decreasedCoverageIcon} | ~~${name}~~ | ~~${diffFileCoverageData.statements.oldPct}~~ | ~~${diffFileCoverageData.branches.oldPct}~~ | ~~${diffFileCoverageData.functions.oldPct}~~ | ~~${diffFileCoverageData.lines.oldPct}~~`;
+        else if (fileRemovedCoverage) {
+            return ` ${removedCoverageIcon} | ~~${name}~~ | ~~${diffFileCoverageData.statements.oldPct}~~ | ~~${diffFileCoverageData.branches.oldPct}~~ | ~~${diffFileCoverageData.functions.oldPct}~~ | ~~${diffFileCoverageData.lines.oldPct}~~`;
         }
         // Coverage existed before so calculate the diff status
         const statusIcon = this.getStatusIcon(diffFileCoverageData);

--- a/dist/index.js
+++ b/dist/index.js
@@ -6683,48 +6683,30 @@ const newCoverageIcon = ':sparkles: :new:';
 const removedCoverageIcon = ':x:';
 class DiffChecker {
     constructor(coverageReportNew, coverageReportOld) {
+        var _a, _b, _c, _d, _e, _f, _g, _h;
         this.diffCoverageReport = {};
         const reportNewKeys = Object.keys(coverageReportNew);
-        for (const key of reportNewKeys) {
-            this.diffCoverageReport[key] = {
+        const reportOldKeys = Object.keys(coverageReportOld);
+        const reportKeys = new Set([...reportNewKeys, ...reportOldKeys]);
+        for (const filePath of reportKeys) {
+            this.diffCoverageReport[filePath] = {
                 branches: {
-                    newPct: this.getPercentage(coverageReportNew[key].branches)
+                    newPct: this.getPercentage((_a = coverageReportNew[filePath]) === null || _a === void 0 ? void 0 : _a.branches),
+                    oldPct: this.getPercentage((_b = coverageReportOld[filePath]) === null || _b === void 0 ? void 0 : _b.branches)
                 },
                 statements: {
-                    newPct: this.getPercentage(coverageReportNew[key].statements)
+                    newPct: this.getPercentage((_c = coverageReportNew[filePath]) === null || _c === void 0 ? void 0 : _c.statements),
+                    oldPct: this.getPercentage((_d = coverageReportOld[filePath]) === null || _d === void 0 ? void 0 : _d.statements)
                 },
                 lines: {
-                    newPct: this.getPercentage(coverageReportNew[key].lines)
+                    newPct: this.getPercentage((_e = coverageReportNew[filePath]) === null || _e === void 0 ? void 0 : _e.lines),
+                    oldPct: this.getPercentage((_f = coverageReportOld[filePath]) === null || _f === void 0 ? void 0 : _f.lines)
                 },
                 functions: {
-                    newPct: this.getPercentage(coverageReportNew[key].functions)
+                    newPct: this.getPercentage((_g = coverageReportNew[filePath]) === null || _g === void 0 ? void 0 : _g.functions),
+                    oldPct: this.getPercentage((_h = coverageReportOld[filePath]) === null || _h === void 0 ? void 0 : _h.functions)
                 }
             };
-        }
-        const reportOldKeys = Object.keys(coverageReportOld);
-        for (const key of reportOldKeys) {
-            if (this.diffCoverageReport[key]) {
-                this.diffCoverageReport[key].statements.oldPct = this.getPercentage(coverageReportOld[key].statements);
-                this.diffCoverageReport[key].branches.oldPct = this.getPercentage(coverageReportOld[key].branches);
-                this.diffCoverageReport[key].functions.oldPct = this.getPercentage(coverageReportOld[key].functions);
-                this.diffCoverageReport[key].lines.oldPct = this.getPercentage(coverageReportOld[key].lines);
-            }
-            else {
-                this.diffCoverageReport[key] = {
-                    branches: {
-                        oldPct: this.getPercentage(coverageReportOld[key].branches)
-                    },
-                    statements: {
-                        oldPct: this.getPercentage(coverageReportOld[key].statements)
-                    },
-                    lines: {
-                        oldPct: this.getPercentage(coverageReportOld[key].lines)
-                    },
-                    functions: {
-                        oldPct: this.getPercentage(coverageReportOld[key].functions)
-                    }
-                };
-            }
         }
     }
     getCoverageDetails(diffOnly, currentDirectory) {
@@ -6782,7 +6764,7 @@ class DiffChecker {
         return 0;
     }
     getPercentage(coverageData) {
-        return coverageData.pct || 0;
+        return (coverageData === null || coverageData === void 0 ? void 0 : coverageData.pct) || 0;
     }
     getStatusIcon(diffFileCoverageData) {
         let overallDiff = 0;

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -156,7 +156,7 @@ export class DiffChecker {
   }
 
   private getPercentage(coverageData: CoverageData): number {
-    return coverageData.pct
+    return coverageData.pct || 0
   }
 
   private getStatusIcon(

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -16,51 +16,26 @@ export class DiffChecker {
     coverageReportOld: CoverageReport
   ) {
     const reportNewKeys = Object.keys(coverageReportNew)
-    for (const key of reportNewKeys) {
-      this.diffCoverageReport[key] = {
+    const reportOldKeys = Object.keys(coverageReportOld)
+    const reportKeys = new Set([...reportNewKeys, ...reportOldKeys])
+
+    for (const filePath of reportKeys) {
+      this.diffCoverageReport[filePath] = {
         branches: {
-          newPct: this.getPercentage(coverageReportNew[key].branches)
+          newPct: this.getPercentage(coverageReportNew[filePath]?.branches),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.branches)
         },
         statements: {
-          newPct: this.getPercentage(coverageReportNew[key].statements)
+          newPct: this.getPercentage(coverageReportNew[filePath]?.statements),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.statements)
         },
         lines: {
-          newPct: this.getPercentage(coverageReportNew[key].lines)
+          newPct: this.getPercentage(coverageReportNew[filePath]?.lines),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.lines)
         },
         functions: {
-          newPct: this.getPercentage(coverageReportNew[key].functions)
-        }
-      }
-    }
-    const reportOldKeys = Object.keys(coverageReportOld)
-    for (const key of reportOldKeys) {
-      if (this.diffCoverageReport[key]) {
-        this.diffCoverageReport[key].statements.oldPct = this.getPercentage(
-          coverageReportOld[key].statements
-        )
-        this.diffCoverageReport[key].branches.oldPct = this.getPercentage(
-          coverageReportOld[key].branches
-        )
-        this.diffCoverageReport[key].functions.oldPct = this.getPercentage(
-          coverageReportOld[key].functions
-        )
-        this.diffCoverageReport[key].lines.oldPct = this.getPercentage(
-          coverageReportOld[key].lines
-        )
-      } else {
-        this.diffCoverageReport[key] = {
-          branches: {
-            oldPct: this.getPercentage(coverageReportOld[key].branches)
-          },
-          statements: {
-            oldPct: this.getPercentage(coverageReportOld[key].statements)
-          },
-          lines: {
-            oldPct: this.getPercentage(coverageReportOld[key].lines)
-          },
-          functions: {
-            oldPct: this.getPercentage(coverageReportOld[key].functions)
-          }
+          newPct: this.getPercentage(coverageReportNew[filePath]?.functions),
+          oldPct: this.getPercentage(coverageReportOld[filePath]?.functions)
         }
       }
     }
@@ -156,7 +131,7 @@ export class DiffChecker {
   }
 
   private getPercentage(coverageData: CoverageData): number {
-    return coverageData.pct || 0
+    return coverageData?.pct || 0
   }
 
   private getStatusIcon(

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -6,7 +6,8 @@ import {DiffCoverageData} from './Model/DiffCoverageData'
 
 const increasedCoverageIcon = ':green_circle:'
 const decreasedCoverageIcon = ':red_circle:'
-const newCoverageIcon = ':new:'
+const newCoverageIcon = ':sparkles: :new:'
+const removedCoverageIcon = ':x:'
 
 export class DiffChecker {
   private diffCoverageReport: DiffCoverageReport = {}
@@ -114,12 +115,18 @@ export class DiffChecker {
     name: string,
     diffFileCoverageData: DiffFileCoverageData
   ): string {
-    if (!diffFileCoverageData.branches.oldPct) {
-      // No old coverage found so that means we added a new file coverage
+    // No old coverage found so that means we added a new file coverage
+    const fileNewCoverage = Object.values(diffFileCoverageData).every(
+      coverageData => coverageData.oldPct === 0
+    )
+    // No new coverage found so that means we deleted a file coverage
+    const fileRemovedCoverage = Object.values(diffFileCoverageData).every(
+      coverageData => coverageData.newPct === 0
+    )
+    if (fileNewCoverage) {
       return ` ${newCoverageIcon} | **${name}** | **${diffFileCoverageData.statements.newPct}** | **${diffFileCoverageData.branches.newPct}** | **${diffFileCoverageData.functions.newPct}** | **${diffFileCoverageData.lines.newPct}**`
-    } else if (!diffFileCoverageData.branches.newPct) {
-      // No new coverage found so that means we added a new deleted coverage
-      return ` ${decreasedCoverageIcon} | ~~${name}~~ | ~~${diffFileCoverageData.statements.oldPct}~~ | ~~${diffFileCoverageData.branches.oldPct}~~ | ~~${diffFileCoverageData.functions.oldPct}~~ | ~~${diffFileCoverageData.lines.oldPct}~~`
+    } else if (fileRemovedCoverage) {
+      return ` ${removedCoverageIcon} | ~~${name}~~ | ~~${diffFileCoverageData.statements.oldPct}~~ | ~~${diffFileCoverageData.branches.oldPct}~~ | ~~${diffFileCoverageData.functions.oldPct}~~ | ~~${diffFileCoverageData.lines.oldPct}~~`
     }
     // Coverage existed before so calculate the diff status
     const statusIcon = this.getStatusIcon(diffFileCoverageData)


### PR DESCRIPTION
## Description

The new and removed checks were happening based on `branch.pct` being 0 in the code coverage data. This is misleading because these values do not indicate the coverage of all the type of that file. 
More so, since it would not display the difference in this type of diff, understanding why the test for delta failed was not clear
example:
<img width="944" alt="Screenshot 2021-03-23 at 9 52 34 PM" src="https://user-images.githubusercontent.com/12022471/112181051-155b1700-8c22-11eb-8b70-266d956a18e6.png">

This PR fixes that mistake and also adds a test case for it
Also updates the icons for new and removed status