### PR TITLE
Add afterSwitchCommand option that allows to run a command after switching to the default branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   runCommand:
     description: 'custom command to get json-summary'
     default: 'npx jest --coverage --coverageReporters="json-summary" --coverageDirectory="./"'
+  afterSwitchCommand:
+    description: 'command to run after switching to default branch'
+    default: null
   delta:
     description: 'Difference between the old and final test coverage'
     default: 100

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ async function run(): Promise<void> {
     const githubToken = core.getInput('accessToken')
     const fullCoverage = JSON.parse(core.getInput('fullCoverageDiff'))
     const commandToRun = core.getInput('runCommand')
+    const commandAfterSwitch = core.getInput('runCommand')
     const delta = Number(core.getInput('delta'))
     const githubClient = github.getOctokit(githubToken)
     const prNumber = github.context.issue.number
@@ -24,6 +25,9 @@ async function run(): Promise<void> {
     execSync('/usr/bin/git fetch')
     execSync('/usr/bin/git stash')
     execSync(`/usr/bin/git checkout --progress --force ${branchNameBase}`)
+    if (commandAfterSwitch) {
+      execSync(commandAfterSwitch)
+    }
     execSync(commandToRun)
     const codeCoverageOld = <CoverageReport>(
       JSON.parse(fs.readFileSync('coverage-summary.json').toString())


### PR DESCRIPTION
This only runs if the option is defined.

Fixes #16

I didn't build the project in this repo since I used [vscode's remote repository extension](https://marketplace.visualstudio.com/items?itemName=GitHub.remotehub), and I didn't want to break anything else too - don't hesitate to hijack my PR and add your own tests / build steps!

It is also my first contribution to a Github Action, so I might've missed some configuration option, please do review this PR before merging it, obviously :)