### PR TITLE
Fix wrong input of afterSwitchCommand

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ async function run(): Promise<void> {
     const githubToken = core.getInput('accessToken')
     const fullCoverage = JSON.parse(core.getInput('fullCoverageDiff'))
     const commandToRun = core.getInput('runCommand')
-    const commandAfterSwitch = core.getInput('runCommand')
+    const commandAfterSwitch = core.getInput('afterSwitchCommand')
     const delta = Number(core.getInput('delta'))
     const githubClient = github.getOctokit(githubToken)
     const prNumber = github.context.issue.number


### PR DESCRIPTION
This has to be done after writing https://github.com/anuraag016/Jest-Coverage-Diff/pull/17 too quickly...

Currently, the run command runs twice (_or should I say thrice, in other words one time too much_) because of this mistake, and since the README mentions to use `uses: anuraag016/Jest-Coverage-Diff@master`, this currently affects everyone who uses this action. It isn't breaking builds, but it's using more time for this action when it shouldn't - and the option is broken, obviously.

More details here : https://github.com/anuraag016/Jest-Coverage-Diff/pull/17#discussion_r681728248

Sorry about that!