### PR TITLE
add ability to compare total coverage number against new total_delta fixes resolves #37

### DIFF
--- a/__tests__/DiffChecker.test.ts
+++ b/__tests__/DiffChecker.test.ts
@@ -1,4 +1,4 @@
-import {DiffChecker} from '../src/DiffChecker'
+import { DiffChecker } from '../src/DiffChecker'
 
 describe('DiffChecker', () => {
   const mock100Coverage = {
@@ -12,6 +12,12 @@ describe('DiffChecker', () => {
     covered: 99,
     skipped: 1,
     pct: 99
+  }
+  const mock98Coverage = {
+    total: 100,
+    covered: 98,
+    skipped: 1,
+    pct: 98
   }
   const mockEmptyCoverage = {
     total: 100,
@@ -30,6 +36,12 @@ describe('DiffChecker', () => {
     branches: mock100Coverage,
     functions: mock100Coverage,
     lines: mock100Coverage
+  }
+  const mock98CoverageFile = {
+    statements: mock98Coverage,
+    branches: mock98Coverage,
+    functions: mock98Coverage,
+    lines: mock98Coverage
   }
   const mockEmptyCoverageFile = {
     statements: mockEmptyCoverage,
@@ -64,5 +76,119 @@ describe('DiffChecker', () => {
       ' :red_circle: | file5 | 99 **(0)** | 0 **(-99)** | 99 **(0)** | 99 **(0)**',
       ' :x: | ~~file4~~ | ~~100~~ | ~~100~~ | ~~100~~ | ~~100~~'
     ])
+  })
+  describe("testing checkIfTestCoverageFallsBelowDelta", () => {
+    describe("respects total_delta for total and delta for other files", () => {
+      it("returns true because delta diff is too high, even if total_delta is okay", () => {
+        const codeCoverageOld = {
+          total: mock100CoverageFile,
+          file1: mock100CoverageFile
+        }
+        const codeCoverageNew = {
+          total: mock98CoverageFile,
+          file1: mock98CoverageFile
+        }
+        const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
+        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(1, 50)
+        expect(isTestCoverageFallsBelowDelta).toBeTruthy();
+      })
+      it("returns true because total_delta diff is too high, even if delta is okay", () => {
+        const codeCoverageOld = {
+          total: mock100CoverageFile,
+          file1: mock100CoverageFile
+        }
+        const codeCoverageNew = {
+          total: mock98CoverageFile,
+          file1: mock98CoverageFile
+        }
+        const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
+        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(50, 1)
+        expect(isTestCoverageFallsBelowDelta).toBeTruthy();
+      })
+      it("returns true if delta diff is too high - total_delta is not defined", () => {
+        const codeCoverageOld = {
+          total: mock100CoverageFile,
+          file1: mock100CoverageFile
+        }
+        const codeCoverageNew = {
+          total: mock98CoverageFile,
+          file1: mock98CoverageFile
+        }
+        const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
+        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(1, null)
+        expect(isTestCoverageFallsBelowDelta).toBeTruthy();
+      })
+      it("returns false if total_delta and delta are okay", () => {
+        const codeCoverageOld = {
+          total: mock100CoverageFile,
+          file1: mock100CoverageFile
+        }
+        const codeCoverageNew = {
+          total: mock98CoverageFile,
+          file1: mock98CoverageFile
+        }
+        const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
+        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(50, 50)
+        expect(isTestCoverageFallsBelowDelta).toBeFalsy();
+      })
+      it("returns false if delta is okay - total_delta is not defined", () => {
+        const codeCoverageOld = {
+          total: mock100CoverageFile,
+          file1: mock100CoverageFile
+        }
+        const codeCoverageNew = {
+          total: mock98CoverageFile,
+          file1: mock98CoverageFile
+        }
+        const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
+        const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(50, null)
+        expect(isTestCoverageFallsBelowDelta).toBeFalsy();
+      })
+    })
+    it("detects that total coverage dropped below total_delta", () => {
+      const codeCoverageOld = {
+        total: mock100CoverageFile,
+      }
+      const codeCoverageNew = {
+        total: mock98CoverageFile,
+      }
+      const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
+      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(2, 1)
+      expect(isTestCoverageFallsBelowDelta).toBeTruthy();
+    })
+    it("detects that total coverage did not drop below total_delta", () => {
+      const codeCoverageOld = {
+        total: mock100CoverageFile,
+      }
+      const codeCoverageNew = {
+        total: mock98CoverageFile,
+      }
+      const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
+      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(1, 5)
+      expect(isTestCoverageFallsBelowDelta).toBeFalsy();
+    })
+    it("detects that total coverage dropped below delta", () => {
+      const codeCoverageOld = {
+        total: mock100CoverageFile,
+      }
+      const codeCoverageNew = {
+        total: mock98CoverageFile,
+      }
+      const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
+      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(1, null)
+      expect(isTestCoverageFallsBelowDelta).toBeTruthy();
+    })
+    it("detects that total coverage did not drop below delta", () => {
+      const codeCoverageOld = {
+        total: mock100CoverageFile,
+      }
+      const codeCoverageNew = {
+        total: mock98CoverageFile,
+      }
+      const diffChecker = new DiffChecker(codeCoverageNew, codeCoverageOld)
+      const isTestCoverageFallsBelowDelta = diffChecker.checkIfTestCoverageFallsBelowDelta(2, null)
+      expect(isTestCoverageFallsBelowDelta).toBeFalsy();
+    })
+
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   delta:
     description: 'Difference between the old and final test coverage'
     default: 100
+  total_delta:
+    description: 'Difference between the old and final test coverage at the total level'
+    default: null
   useSameComment:
     description: 'While commenting on the PR update the exisiting comment'
     default: false

--- a/src/DiffChecker.ts
+++ b/src/DiffChecker.ts
@@ -67,10 +67,13 @@ export class DiffChecker {
     return returnStrings
   }
 
-  checkIfTestCoverageFallsBelowDelta(delta: number): boolean {
-    const keys = Object.keys(this.diffCoverageReport)
-    for (const key of keys) {
-      const diffCoverageData = this.diffCoverageReport[key]
+  checkIfTestCoverageFallsBelowDelta(
+    delta: number,
+    totalDelta: number | null
+  ): boolean {
+    const files = Object.keys(this.diffCoverageReport)
+    for (const file of files) {
+      const diffCoverageData = this.diffCoverageReport[file]
       const keys: ('lines' | 'statements' | 'branches' | 'functions')[] = <
         ('lines' | 'statements' | 'branches' | 'functions')[]
       >Object.keys(diffCoverageData)
@@ -84,7 +87,11 @@ export class DiffChecker {
       }
       for (const key of keys) {
         if (diffCoverageData[key].oldPct !== diffCoverageData[key].newPct) {
-          if (-this.getPercentageDiff(diffCoverageData[key]) > delta) {
+          const deltaToCompareWith =
+            file === 'total' && totalDelta !== null ? totalDelta : delta
+          if (
+            -this.getPercentageDiff(diffCoverageData[key]) > deltaToCompareWith
+          ) {
             return true
           }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ async function run(): Promise<void> {
     const commandToRun = core.getInput('runCommand')
     const commandAfterSwitch = core.getInput('afterSwitchCommand')
     const delta = Number(core.getInput('delta'))
+    const rawTotalDelta = core.getInput('total_delta')
     const githubClient = github.getOctokit(githubToken)
     const prNumber = github.context.issue.number
     const branchNameBase = github.context.payload.pull_request?.base.ref
@@ -25,6 +26,10 @@ async function run(): Promise<void> {
     const useSameComment = JSON.parse(core.getInput('useSameComment'))
     const commentIdentifier = `<!-- codeCoverageDiffComment -->`
     const deltaCommentIdentifier = `<!-- codeCoverageDeltaComment -->`
+    let totalDelta = null
+    if (rawTotalDelta !== null) {
+      totalDelta = Number(rawTotalDelta)
+    }
     let commentId = null
     execSync(commandToRun)
     const codeCoverageNew = <CoverageReport>(
@@ -81,7 +86,7 @@ async function run(): Promise<void> {
     )
 
     // check if the test coverage is falling below delta/tolerance.
-    if (diffChecker.checkIfTestCoverageFallsBelowDelta(delta)) {
+    if (diffChecker.checkIfTestCoverageFallsBelowDelta(delta, totalDelta)) {
       if (useSameComment) {
         commentId = await findComment(
           githubClient,


### PR DESCRIPTION
Adds the ability to be able to compare the total coverage changes in a change against a new `total_delta` value

The `delta` value was per file; however there are times where someone may be interested in only comparing against the total changes, and not so much at a per file granularity. Or if they wish to have different deltas (i.e. a smaller delta repo wise and larger delta at a file level)

would resolve: https://github.com/anuraag016/Jest-Coverage-Diff/issues/37