### PR TITLE
Fix total_delta incorrect parse (ignoring null values)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ async function run(): Promise<void> {
     const commentIdentifier = `<!-- codeCoverageDiffComment -->`
     const deltaCommentIdentifier = `<!-- codeCoverageDeltaComment -->`
     let totalDelta = null
-    if (rawTotalDelta !== null) {
+    if (rawTotalDelta !== '') {
       totalDelta = Number(rawTotalDelta)
     }
     let commentId = null


### PR DESCRIPTION
This PR fixes `total_delta` parse error. 

When total_delta is not passed to the action, it should hold the [null](https://github.com/anuraag016/Jest-Coverage-Diff/blob/6d84e08a37e179ffd7e233541e38afdd8cf41697/action.yml#L22) - the default value - [inheriting](https://github.com/anuraag016/Jest-Coverage-Diff/blob/6d84e08a37e179ffd7e233541e38afdd8cf41697/src/DiffChecker.ts#L95) the delta value in `checkIfTestCoverageFallsBelowDelta` method.   

However, since [getInput](https://github.com/anuraag016/Jest-Coverage-Diff/blob/6d84e08a37e179ffd7e233541e38afdd8cf41697/src/main.ts#L21) returns an empty string and not a null value,  total_delta is attributed with the [result](https://github.com/anuraag016/Jest-Coverage-Diff/blob/6d84e08a37e179ffd7e233541e38afdd8cf41697/src/main.ts#L31) of `Number("")` which is 0, and hence, total_delta never inherits the given delta value. 

